### PR TITLE
[TSK-100]メールアドレス、パスワード認証を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.pyc
 .DS_Store
 .env
+serviceAccountKey.json

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,51 @@
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
+from fastapi import FastAPI, Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from pydantic import BaseModel
+import firebase_admin
+from firebase_admin import auth, credentials
 
+cred = credentials.Certificate("./serviceAccountKey.json")
+firebase_admin.initialize_app(cred)
+
+# サーバーの起動
 app = FastAPI()
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # フロントエンドのオリジン
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# リクエストボディの定義
+class Message(BaseModel):
+    name: str
+
+def get_current_user(cred: HTTPAuthorizationCredentials = Depends(HTTPBearer())):
+    if not cred:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"}
+        )
+    try:
+        token = cred.credentials
+        decoded_token = auth.verify_id_token(token)
+        print(f"Decoded Token: {decoded_token}")
+        return decoded_token
+    except Exception as e:
+        print(f"Token verification error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"}
+        )
 
 @app.get("/")
 async def root():
     return {"message": "Hello World"}
+
+# getを定義
+@app.get("/hello")
+def read_root(cred = Depends(get_current_user)):
+    uid = cred.get("uid")
+    return {"message": f"Hello, {uid}!"}
+
+# postを定義
+@app.post("/hello")
+def create_message(message: Message, cred = Depends(get_current_user)):
+    uid = cred.get("uid")
+    return {"message": f"Hello, {message.name}! Your uid is [{uid}]"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ dnspython==2.6.1
 email_validator==2.1.1
 fastapi==0.111.0
 fastapi-cli==0.0.3
+firebase-admin==6.5.0
 h11==0.14.0
 httpcore==1.0.5
 httptools==0.6.1


### PR DESCRIPTION
## やったこと
メールアドレス、パスワード認証を実装

## やっていないこと
エンドポイントを実装したが、フロント側にはログインフォームを作成していないので、postmanからしか叩けない
入力フォームの側のみ作成したため、インプットボックスはコンポーネントとして作成する必要あり

## 今後やること
ログインフォーム内にインプットボックス作成
コンポーネント化して保守性向上させる
ログインステータスをグローバルに管理して手間を減らす
ログイン済みの際のリンクのアクセス許可
認証勝利の部分をフックスに切り出す